### PR TITLE
Use oldest-supported-numpy as build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["Cython>=0.23", "numpy", "setuptools", "wheel"]
+requires = ["Cython>=0.23", "oldest-supported-numpy", "setuptools", "wheel"]


### PR DESCRIPTION
Fixes incompatible numpy versions build vs runtime, as NumPy
v1.20 is binary incompatible with older versions.

See https://github.com/pypa/pip/issues/9542