### PR TITLE
NumPy 2.0 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,18 @@
-[build-system]
-requires = ["Cython>=0.23", "numpy>=2.0.0rc1", "setuptools", "wheel"]
-
 [project]
 name = "hdmedians"
-version = "0.14.3a0"
+description = "High-dimensional medians"
+authors = [
+    {name = "Dale Roberts", email = "dale.o.roberts@gmail.com"}
+]
+license = "Apache-2.0"
+version = "0.14.2"
 dependencies = [
     "numpy>=1.21"
 ]
 
+[project.urls]
+Homepage = "http://github.com/daleroberts/hdmedians"
+
+[build-system]
+requires = ["Cython", "numpy>=2.0.0rc1", "setuptools"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,10 @@
 [build-system]
-requires = ["Cython>=0.23", "oldest-supported-numpy", "setuptools", "wheel"]
+requires = ["Cython>=0.23", "numpy>=2.0.0rc1", "setuptools", "wheel"]
+
+[project]
+name = "hdmedians"
+version = "0.14.3a0"
+dependencies = [
+    "numpy>=1.21"
+]
+

--- a/setup.py
+++ b/setup.py
@@ -12,15 +12,4 @@ extensions = [Extension('hdmedians.geomedian',
                         ['hdmedians/geomedian.pyx'],
                         include_dirs = [np.get_include()])]
 
-setup(name='hdmedians',
-      packages=find_packages(),
-      setup_requires=['nose>=1.0', 'Cython>=0.23'],
-      install_requires=['numpy>=1.21', 'Cython>=0.23'],
-      version='0.14.2',
-      description='High-dimensional medians',
-      url='http://github.com/daleroberts/hdmedians',
-      author='Dale Roberts',
-      author_email='dale.o.roberts@gmail.com',
-      license='Apache License, Version 2.0',
-#      cmdclass = {'build_ext': build_ext},
-      ext_modules = extensions)
+setup(packages=find_packages(), ext_modules = extensions)


### PR DESCRIPTION
Prior to this PR, if `hdmedians` is compiled in an Python environment that uses Numpy 2.0+, `import hdmedians` results in the following error:

```text
A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.2.5 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.

Traceback ...

ImportError: numpy.core.multiarray failed to import (auto-generated because you didn't call 'numpy.import_array()' after cimporting numpy; use '<void>numpy._import_array' to disable if you are certain you don't need it).
```

This is because `hdmedians` builds with `oldest-supported-numpy` (a version of NumPy 1.x.x). 

This change makes `setuptools` use NumPy 2.0+ to compile hdmedians, but still work with NumPy < 2. This is done according to <https://numpy.org/doc/2.2/dev/depending_on_numpy.html#numpy-2-0-specific-advice>.

Note that with this change most of the project parameters have been moved to `pyproject.toml`.